### PR TITLE
Added link to the Europeana object from DRI object

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -118,6 +118,14 @@ class SolrDocument
     Solr::Query.new(files_query).count > 0
   end
 
+  def valid_edm?
+    files_query = "active_fedora_model_ssi:\"DRI::GenericFile\""
+    files_query += " AND isPartOf_ssim:#{alternate_id}"
+    files_query += " AND (file_type_sim:\"3d\" OR file_type_sim:\"video\" OR file_type_sim:\"audio\" OR file_type_sim:\"text\" OR file_type_sim:\"image\")"
+  
+    Solr::Query.new(files_query).count > 0
+  end
+  
   def doi
     self['doi_ss']
   end
@@ -142,6 +150,15 @@ class SolrDocument
 
   def has_geocode?
     self['geojson_ssim'].present?
+  end
+
+  def has_aggregation_data?
+    aggID = Aggregation.find_or_create_by(collection_id: root_collection_id).aggregation_id
+    if (aggID != nil && aggID.length > 0)
+      return true
+    else
+      return false
+    end
   end
 
   # @param [String] field_name

--- a/app/views/shared/_tools.html.erb
+++ b/app/views/shared/_tools.html.erb
@@ -32,6 +32,12 @@
 			<%= link_to t('blacklight.tools.cite'), citation_object_path(@document), id: 'show_citation', :'data-toggle' => 'modal',  :'data-target' => '#dri_citation_modal_id' %>
 		</li>
 
+		<% if @document.has_aggregation_data? && @document.public_read? && !@assets.empty? && @document.valid_edm?%>
+			<li>
+				<%= europeana_url = (link_to t('dri.views.catalog.forms.europeana_link'), Settings.transcribathon.link_item + Aggregation.find_or_create_by(collection_id: @document.root_collection_id).aggregation_id + '/' + @document.id, :target => '_blank') %>
+			</li>
+		<% end %>
+
 		<% if (can? :edit, @document) %>
 		  <li>
 			  <%= link_to t('dri.views.catalog.links.history'), object_history_path(@document.id), id: 'show_object_history_report' %>

--- a/config/locales/dri/en.yml
+++ b/config/locales/dri/en.yml
@@ -426,6 +426,7 @@ en:
             last_modified: Last Update
           bookmark_collection: Bookmark Collection
           bookmark_object: Bookmark Object
+          europeana_link: Europeana Link
           download: Download
           download_all:
             one: Download entire object including the asset

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -40,3 +40,11 @@ transcribathon:
   story_endpoint: "https://transcribathon.eu/tp-api/stories/"
   item_endpoint: "https://transcribathon.eu/tp-api/items/"
   wikidata_endpoint: "https://www.wikidata.org/wiki/"
+  link_item: "https://www.europeana.eu/en/item/"
+edm:
+  _3d: "3D"
+  video: ["MOVINGIMAGE", "MOVING IMAGE", "VIDEO"]
+  sound: ["SOUND","AUDIO"]
+  text: "TEXT"
+  image: ["IMAGE", "STILLIMAGE", "STILL IMAGE"]
+

--- a/lib/dri/formatters/edm.rb
+++ b/lib/dri/formatters/edm.rb
@@ -469,11 +469,11 @@ class DRI::Formatters::EDM < OAI::Provider::Metadata::Format
 
   def self.edm_type(types)
     types = types.map(&:upcase)
-    return "3D" if types.include?("3D")
-    return "VIDEO" if types.to_set.intersect?(["MOVINGIMAGE", "MOVING IMAGE", "VIDEO"].to_set)
-    return "SOUND" if types.to_set.intersect?(["SOUND","AUDIO"].to_set)
-    return "TEXT" if types.include?("TEXT")
-    return "IMAGE" if types.to_set.intersect?(["IMAGE", "STILLIMAGE", "STILL IMAGE"].to_set)
+    return "3D" if types.include?(Settings.edm._3d)
+    return "VIDEO" if types.to_set.intersect?(Settings.edm.video .to_set)
+    return "SOUND" if types.to_set.intersect?(Settings.edm.sound.to_set)
+    return "TEXT" if types.include?(Settings.edm.text)
+    return "IMAGE" if types.to_set.intersect?(Settings.edm.image.to_set)
     return "INVALID"
   end
 


### PR DESCRIPTION
 **Added link to the Europeana object from DRI object**

 **Tickets:**
<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;sbWEiXME&#x2F;123-add-a-link-to-the-europeana-object-from-the-dri-object">Add a link to the Europeana object from the DRI object</a></blockquote>
<blockquote class="trello-card"><a href="https:&#x2F;&#x2F;trello.com&#x2F;c&#x2F;VAqTklNz&#x2F;158-from-requirements-add-a-link-to-the-europeana-object-from-the-dri-object">[From Requirements] Add a link to the Europeana object from the DRI object</a></blockquote>

**Description:**
Render element to user, when user clicks it open a new page on Europeana website, the link is composed by:
Str: "https://www.europeana.eu/en/item/" + Var: Collection ID +  Var: Europeana Aggregation ID 

do **NOT** print link if:
- Aggregation data not present
- Object has access restricted;
- No valid EDM type;
- There's no asset in the object;

**Note:** EDM types moved to settings.yml

**UI/UX**
![image](https://user-images.githubusercontent.com/115575268/228583353-2d79b9c3-8623-4439-aba3-197f33dda578.png)
image1: new option added to object tools leading user to Europeana webpage


**Tests results**
During the tests a new collection was created with multiple objects and different files as image 2
![image](https://user-images.githubusercontent.com/115575268/228584086-5c4efde0-31ca-41e7-926b-c0eefd6bee76.png)
image2: objects in the collection for test purpose.

![image](https://user-images.githubusercontent.com/115575268/228592698-9afd2532-6299-4d54-99a9-c34153d49572.png)
Image3: Test results 

