### PR TITLE
3D_Viewer-DRACOLoader_fix

### DIFF
--- a/app/assets/javascripts/three_js_viewer.js
+++ b/app/assets/javascripts/three_js_viewer.js
@@ -96,7 +96,9 @@ $(document).ready(function () {
         case 'glb':
         case 'gltf':
             var dracoLoader = new THREE.DRACOLoader();
-            dracoLoader.setDecoderPath('/assets/Three/lib/three/examples/js/libs/draco/')
+            // dracoLoader.setDecoderPath('/assets/Three/lib/three/examples/js/libs/draco/')
+            dracoLoader.setDecoderPath('https://www.gstatic.com/draco/versioned/decoders/1.4.1/');
+            dracoLoader.setDecoderConfig({ type: 'js' });
             var gltfLoader = new THREE.GLTFLoader();
             gltfLoader.setDRACOLoader( dracoLoader );
             gltfLoader.load( url, function (gltf) {

--- a/app/assets/javascripts/three_js_viewer.js
+++ b/app/assets/javascripts/three_js_viewer.js
@@ -96,7 +96,6 @@ $(document).ready(function () {
         case 'glb':
         case 'gltf':
             var dracoLoader = new THREE.DRACOLoader();
-            // dracoLoader.setDecoderPath('/assets/Three/lib/three/examples/js/libs/draco/')
             dracoLoader.setDecoderPath('https://www.gstatic.com/draco/versioned/decoders/1.4.1/');
             dracoLoader.setDecoderConfig({ type: 'js' });
             var gltfLoader = new THREE.GLTFLoader();


### PR DESCRIPTION
- importing DRACO Loader file via CDN
Note: it's used for handling files type GLTF, GLB and GLB compressed.