### PR TITLE
Fix_Europeana_Link

### DIFF
--- a/app/views/shared/_tools.html.erb
+++ b/app/views/shared/_tools.html.erb
@@ -34,7 +34,7 @@
 
 		<% if @document.has_aggregation_data? && @document.public_read? && !@assets.empty? && @document.valid_edm?%>
 			<li>
-				<%= europeana_url = (link_to t('dri.views.catalog.forms.europeana_link'), Settings.transcribathon.link_item + Aggregation.find_or_create_by(collection_id: @document.root_collection_id).aggregation_id + '/' + @document.id, :target => '_blank') %>
+				<%= europeana_url = (link_to t('dri.views.catalog.forms.europeana_link'), Settings.transcribathon.link_item + Aggregation.find_or_create_by(collection_id: @document.root_collection_id).aggregation_id + '/_' + @document.id, :target => '_blank') %>
 			</li>
 		<% end %>
 


### PR DESCRIPTION
Due to the test error in [Dublin Castle Tracts](https://repository.dri.ie/catalog/n584bh18n) I'm including the hard-coded "_" before <object_id> as instructed and checking if all Europeana Collections to be aggregated has this pattern as it may not work in all cases if negative.

before:    https://www.europeana.eu/en/item/<aggregationid>/<object_id>
This PR: https://www.europeana.eu/en/item/<aggregationid>/_<object_id>