### PR TITLE
Fair signposting level 2

### DIFF
--- a/app/controllers/signposting_header_lset_controller.rb
+++ b/app/controllers/signposting_header_lset_controller.rb
@@ -1,0 +1,68 @@
+class SignpostingHeaderLsetController < ApplicationController
+    include SignpostingHeaderHelper
+    require 'json'
+    require 'net/http'
+    require 'uri'
+    require 'rsolr'
+    require 'blacklight/catalog'
+
+    def lset
+        id = params[:id]
+
+        @document = solr_request(id, true)
+        
+        schema_link = mapped_links(@document.type, SCHEMA_TYPES)
+        
+        doi = DataciteDoi.where(object_id: @document.id).current
+        @doi = doi.doi if doi.present? && doi.minted?
+        
+        orcid_links = get_contributors(@document['contributor_tesim'])
+        
+        license_link = @document.licence.url
+    
+        assets = @document.assets
+        link_assets = object_items(assets, id)
+    
+        describedby = metadata_link(id)
+    
+        linkset = []
+    
+        if @doi.present?
+            linkset << "<#{"https://doi.org/"+ doi.doi}> ; rel=\"cite-as\" ; anchor=\"https://repository.dri.ie/catalog/#{id}\""
+        end
+
+        if schema_link.present?
+          linkset << "<#{schema_link}> ; rel=\"type\" ; anchor=\"https://repository.dri.ie/catalog/#{id}\""
+        end
+        linkset << "<https://schema.org/AboutPage> ; rel=\"type\" ; anchor=\"https://repository.dri.ie/catalog/#{id}\""
+
+        if orcid_links.present?
+            orcid_links.each do |orcid|
+                linkset << "<#{orcid}> ; rel=\"author\" ; anchor=\"https://repository.dri.ie/catalog/#{id}\""
+            end
+        end
+
+        if link_assets.present?
+            link_assets.each do |asset|
+                linkset << "<#{asset[:href]}> ; rel=\"item\" ; type=\"#{asset[:type]}\" ; anchor=\"https://repository.dri.ie/catalog/#{id}\""
+            end
+        end
+
+        linkset << "<#{describedby[:href]}> ; rel=\"describedby\" ; type=\"application/xml\" ; anchor=\"https://repository.dri.ie/catalog/#{id}\""
+
+        if license_link.present?
+          linkset << "<#{license_link}> ; rel=\"license\" ; anchor=\"https://repository.dri.ie/catalog/#{id}\""
+        end
+
+        ancestor_id = @document['ancestor_id_ssim']
+
+        reverse_link = reverse_link_builder(link_assets, ancestor_id, id)
+        reverse_link.each do |item|
+            item_json = JSON.parse(item.to_json)
+            linkset << "<#{item_json["collection"][0]["href"]}> ; rel=\"collection\" ; type=\"#{item_json["collection"][0]["type"]}\" ; anchor=\"#{item_json["anchor"]}\""
+        end
+
+        response.headers['Content-Type'] = 'application/linkset'
+        render plain: linkset.join(" , \n")+"\n\n"
+    end
+end

--- a/app/controllers/signposting_header_lset_controller.rb
+++ b/app/controllers/signposting_header_lset_controller.rb
@@ -3,9 +3,7 @@ class SignpostingHeaderLsetController < ApplicationController
     require 'json'
     require 'net/http'
     require 'uri'
-    require 'rsolr'
-    require 'blacklight/catalog'
-
+    
     def lset
         id = params[:id]
 

--- a/app/controllers/signposting_header_lset_json_controller.rb
+++ b/app/controllers/signposting_header_lset_json_controller.rb
@@ -1,0 +1,72 @@
+class SignpostingHeaderLsetJsonController < ApplicationController
+  include SignpostingHeaderHelper
+  require 'json'
+  require 'net/http'
+  require 'uri'
+  require 'rsolr'
+  require 'blacklight/catalog'
+
+  def json
+    id = params[:id]
+
+    @document = solr_request(id, true)
+    
+    schema_link = mapped_links(@document.type, SCHEMA_TYPES);
+     
+    doi = DataciteDoi.where(object_id: @document.id).current
+    @doi = doi.doi if doi.present? && doi.minted?
+
+    orcid_links = get_contributors(@document['contributor_tesim'])
+    
+    license_link = @document.licence.url
+
+    assets = @document.assets
+    link_assets = object_items(assets, id)
+      
+    describedby = metadata_link(id)
+
+    linkset = {}
+
+    linkset[:anchor] = "https://repository.dri.ie/catalog/#{id}"
+
+    if @doi.present?
+      linkset[:"cite-as"] = [{"href" => "https://doi.org/"+ doi.doi}] 
+    end
+
+    if schema_link.present?
+      linkset[:type] = [{"href" => schema_link},{"href" => "https://schema.org/AboutPage"}]
+    else
+      linkset[:type] = [{"href" => "https://schema.org/AboutPage"}]
+    end
+
+    if orcid_links.present?
+      orcid = []
+      orcid_links.each do |author|
+        holder = {}
+        holder[:href] = author
+        orcid << holder
+      end
+      linkset[:author] = orcid  
+    end
+
+    if link_assets.present?
+      linkset[:item] = link_assets
+    end
+
+    linkset[:describedby] = [describedby]
+
+    if license_link.present?
+      linkset[:license] = [{"href" => license_link}]
+    end
+
+    ancestor_id = @document['ancestor_id_ssim']
+    reverse_link = reverse_link_builder(link_assets, ancestor_id, id)
+
+    linkset_hash = { "linkset" => [linkset, reverse_link] }
+    response.headers['Content-Type'] = 'application/linkset+json'
+    render json: JSON.pretty_generate(linkset_hash) + "\n\n"
+
+  end
+  private
+end
+  

--- a/app/controllers/signposting_header_lset_json_controller.rb
+++ b/app/controllers/signposting_header_lset_json_controller.rb
@@ -3,8 +3,6 @@ class SignpostingHeaderLsetJsonController < ApplicationController
   require 'json'
   require 'net/http'
   require 'uri'
-  require 'rsolr'
-  require 'blacklight/catalog'
 
   def json
     id = params[:id]
@@ -65,8 +63,6 @@ class SignpostingHeaderLsetJsonController < ApplicationController
     linkset_hash = { "linkset" => [linkset, reverse_link] }
     response.headers['Content-Type'] = 'application/linkset+json'
     render json: JSON.pretty_generate(linkset_hash) + "\n\n"
-
   end
-  private
 end
   

--- a/app/helpers/signposting_header_helper.rb
+++ b/app/helpers/signposting_header_helper.rb
@@ -1,0 +1,136 @@
+module SignpostingHeaderHelper
+  require 'json'
+
+  private
+
+    SCHEMA_TYPES = {
+      'text' 			          => 'https://schema.org/DigitalDocument',
+      'image' 			        => 'https://schema.org/ImageObject',
+      'movingimage' 		    => 'https://schema.org/VideoObject',
+      'interactiveresource' => 'https://schema.org/WebApplication',
+      'sound' 			        => 'https://schema.org/AudioObject',
+      'software' 		        => 'https://schema.org/SoftwareApplication',
+      'dataset' 			      => 'https://schema.org/Dataset',
+      'article'             => 'https://schema.org/ScholarlyArticle',
+      'collection'          => 'https://schema.org/Collection',
+      'object'              => 'https://schema.org/object',
+      '3d'                  => 'https://schema.org/3DModel'
+    }.freeze
+
+    XML_PROFILE = {
+      'DRI::QualifiedDublinCore'  => 'http://dublincore.org/schemas/xmls/qdc/2008/02/11/qualifieddc.xsd',
+      'DRI::Mods'                 => 'http://www.loc.gov/standards/mods/v3/mods-3-7.xsd',
+      'DRI::EadComponent'         => 'http://www.loc.gov/ead/ead.xsd',
+      'DRI::EadCollection'        => 'http://www.loc.gov/ead/ead.xsd',
+      'DRI::Marc'                 => 'http://www.loc.gov/standards/marcxml/schema/MARC21slim.xsd'
+    }.freeze
+
+    def solr_request(id_target, is_essential)
+      @document = SolrDocument.find("#{id_target}")
+
+      if @document.present? && @document.object? && @document['file_count_isi'].present? && @document.published?
+        return @document
+      else
+        raise DRI::Exceptions::BadRequest, 'Invalid ID provided'
+      end
+
+    end
+
+    def mapped_links (target_types, map)
+      target_types.each do |type|
+        link = map[type]
+        if link.present?
+          return link
+        end
+      end
+      return nil
+    end
+
+    def get_contributors(contributors)
+
+      if contributors.present?
+        identifiers = contributors.map do |entry|
+          match = entry.match(/identifier=(https:\/\/orcid\.org\/\d{4}-\d{4}-\d{4}-\d{4})/)
+          match&.captures&.first
+        end.compact
+        return identifiers
+      else
+        return nil
+      end
+    end
+  
+    def object_items(assets, id)
+      asset_link = []
+      assets.each do |asset|
+        id_file = asset&.fetch("id", nil).to_s.gsub(/[\[\]"]/, '')
+        mime_type = asset&.fetch("mime_type_tesim", nil).to_s.gsub(/[\[\]"]/, '')
+
+        if asset.text? || asset.pdf?
+          if mime_type.include?('application/pdf')
+            item_link(asset, id, asset_link, "surogate", id_file, mime_type)
+          else 
+            item_link(asset, id, asset_link, "surogate", id_file, "application/pdf")
+            if @document.read_master? && asset.text? && !mime_type.include?('application/pdf')
+              item_link(asset, id, asset_link, "masterfile", id_file, mime_type)
+            end
+          end
+        elsif asset.threeD?
+          if @document.read_master?
+            item_link(asset, id, asset_link, "masterfile", id_file, mime_type)
+          else
+            item_link(asset, id, asset_link, "surogate", id_file, mime_type)
+          end
+        else
+          item_link(asset, id, asset_link, "surogate", id_file, mime_type)
+        end
+      end
+
+      return asset_link
+    end
+
+    def item_link(asset, id, asset_link, type, id_file, mime_type)
+      place_holder = {}
+      file = "http://repository.dri.ie/objects/#{id}/files/#{id_file}/download?type=#{type}"
+      place_holder[:href] = file
+      place_holder[:type] = mime_type
+      asset_link << place_holder
+    end
+  
+    def metadata_link(id)
+      describedby_link = {}
+      metadata_type = "application/xml"
+      metadata_url = "http://repository.dri.ie/objects/#{id}/metadata"
+      describedby_link [:href] = metadata_url
+      describedby_link [:type] = metadata_type
+      xml_type = @document['has_model_ssim']
+      profile = mapped_links(xml_type, XML_PROFILE)
+
+      if profile.present?
+        describedby_link [:profile] = profile
+      end
+
+      return describedby_link
+    end
+
+    def reverse_link_builder (link_assets, ancestor_id, object_id)
+      reverse = []
+      ancestor_link = "https://repository.dri.ie/catalog/#{ancestor_id.first}" 
+      object_link = "https://repository.dri.ie/catalog/#{object_id}" 
+      
+      link_assets.each do|item|
+        place_holder = {}
+        arr_holder = []
+        collection = {}
+        collection[:href] = ancestor_link
+        collection[:type] = "text/html"
+        arr_holder << collection
+        anchor = item.to_a
+        place_holder[:anchor] = anchor[0][1] || nil
+        place_holder[:collection] = arr_holder
+        reverse << place_holder
+      end
+
+      return reverse
+    end
+
+  end

--- a/app/helpers/signposting_header_helper.rb
+++ b/app/helpers/signposting_header_helper.rb
@@ -33,7 +33,6 @@ module SignpostingHeaderHelper
       else
         raise DRI::Exceptions::BadRequest, 'Invalid ID provided'
       end
-
     end
 
     def mapped_links (target_types, map)
@@ -43,20 +42,19 @@ module SignpostingHeaderHelper
           return link
         end
       end
-      return nil
+      
+      nil
     end
 
     def get_contributors(contributors)
-
-      if contributors.present?
-        identifiers = contributors.map do |entry|
-          match = entry.match(/identifier=(https:\/\/orcid\.org\/\d{4}-\d{4}-\d{4}-\d{4})/)
-          match&.captures&.first
-        end.compact
-        return identifiers
-      else
-        return nil
-      end
+      return nil unless contributors.present?
+      
+      identifiers = contributors.map do |entry|
+        match = entry.match(/identifier=(https:\/\/orcid\.org\/\d{4}-\d{4}-\d{4}-\d{4})/)
+        match&.captures&.first
+      end.compact
+        
+      identifiers
     end
   
     def object_items(assets, id)
@@ -67,9 +65,9 @@ module SignpostingHeaderHelper
 
         if asset.text? || asset.pdf?
           if mime_type.include?('application/pdf')
-            item_link(asset, id, asset_link, "surogate", id_file, mime_type)
+            item_link(asset, id, asset_link, "surrogate", id_file, mime_type)
           else 
-            item_link(asset, id, asset_link, "surogate", id_file, "application/pdf")
+            item_link(asset, id, asset_link, "surrogate", id_file, "application/pdf")
             if @document.read_master? && asset.text? && !mime_type.include?('application/pdf')
               item_link(asset, id, asset_link, "masterfile", id_file, mime_type)
             end
@@ -78,19 +76,19 @@ module SignpostingHeaderHelper
           if @document.read_master?
             item_link(asset, id, asset_link, "masterfile", id_file, mime_type)
           else
-            item_link(asset, id, asset_link, "surogate", id_file, mime_type)
+            item_link(asset, id, asset_link, "surrogate", id_file, mime_type)
           end
         else
-          item_link(asset, id, asset_link, "surogate", id_file, mime_type)
+          item_link(asset, id, asset_link, "surrogate", id_file, mime_type)
         end
       end
 
-      return asset_link
+      asset_link
     end
 
     def item_link(asset, id, asset_link, type, id_file, mime_type)
       place_holder = {}
-      file = "http://repository.dri.ie/objects/#{id}/files/#{id_file}/download?type=#{type}"
+      file = "https://repository.dri.ie/objects/#{id}/files/#{id_file}/download?type=#{type}"
       place_holder[:href] = file
       place_holder[:type] = mime_type
       asset_link << place_holder
@@ -99,7 +97,7 @@ module SignpostingHeaderHelper
     def metadata_link(id)
       describedby_link = {}
       metadata_type = "application/xml"
-      metadata_url = "http://repository.dri.ie/objects/#{id}/metadata"
+      metadata_url = "https://repository.dri.ie/objects/#{id}/metadata"
       describedby_link [:href] = metadata_url
       describedby_link [:type] = metadata_type
       xml_type = @document['has_model_ssim']
@@ -109,7 +107,7 @@ module SignpostingHeaderHelper
         describedby_link [:profile] = profile
       end
 
-      return describedby_link
+      describedby_link
     end
 
     def reverse_link_builder (link_assets, ancestor_id, object_id)
@@ -130,7 +128,6 @@ module SignpostingHeaderHelper
         reverse << place_holder
       end
 
-      return reverse
+      reverse
     end
-
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,15 @@
     <meta charset="utf-8">
     <meta http-equiv="Content-Type" content="text/html" charset="utf-8">
 
+    
+    <% if request.path =~ %r{^/catalog/} && @document.object?%>
+      <!-- FAIR Signposting https://signposting.org/FAIR -->
+      <%path_seg = request.path.split('/')%>
+      <%id = path_seg.last%>
+      <link href= "http://repository.dri.ie/linkset/<%=id%>/json"  rel="linkset"  type="application/linkset+json">
+      <link href= "http://repository.dri.ie/linkset/<%=id%>/lset"  rel="linkset"  type="application/linkset">
+    <% end %>
+
     <!-- Mobile viewport optimization h5bp.com/ad -->
     <meta name="HandheldFriendly" content="True">
     <meta name="apple-mobile-web-app-capable" content="yes">

--- a/config/application.rb
+++ b/config/application.rb
@@ -79,5 +79,8 @@ module DriApp
 
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
+
+    config.autoload_paths << Rails.root.join('lib')
+
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -175,6 +175,9 @@ Rails.application.routes.draw do
     get 'aggregations/:id' => 'aggregations#edit', as: :edit_edm_settings
     put 'aggregations/:id' => 'aggregations#update', as: :save_edm_settings
 
+    get 'linkset/:id/json' => 'signposting_header_lset_json#json'
+    get 'linkset/:id/lset' => 'signposting_header_lset#lset'
+
     #API paths
     post 'get_objects' => 'api#objects'
     get 'related' => 'api#related'

--- a/spec/helpers/signposting_header_helper_spec.rb
+++ b/spec/helpers/signposting_header_helper_spec.rb
@@ -1,0 +1,304 @@
+# spec/helpers/signposting_header_helper_spec.rb
+
+require 'rails_helper'
+include SignpostingHeaderHelper
+
+RSpec.describe SignpostingHeaderHelper, type: :helper do
+  let(:id) { '1' }
+
+  describe '#mapped_links' do
+    let(:target_types) { ['unknown_type', 'text', '3d'] }
+    let(:target_3d) { ['unknown_type','3d', 'text'] }
+    let(:target_unknown) { ['unknown_type'] }
+    let(:target_empty) { [] }
+    let(:map) do
+      {
+        'text' => 'https://schema.org/text_link',
+        '3d'   => 'https://schema.org/3DModel'
+      }
+    end
+
+    it 'returns the first link that is present in the map' do
+      result = mapped_links(target_types, map)
+      expect(result).to eq('https://schema.org/text_link')
+    end
+
+    it 'returns the last link that is present in the map' do
+      result = mapped_links(target_3d, map)
+      expect(result).to eq('https://schema.org/3DModel')
+    end
+
+    it 'returns nil if no link not present in the map' do
+      result = mapped_links([target_unknown], map)
+      expect(result).to be_nil
+    end
+
+    it 'returns nil if target_types is empty' do
+      result = mapped_links(target_empty, map)
+      expect(result).to be_nil
+    end
+  end
+
+  describe '#get_contributors' do 
+    let(:identifiers) {[
+      'name=Test, Test; authority=ORCID; identifier=https://orcid.org/0000-0000-0000-0000', 
+      'name=Test1, Test1; authority=ORCID; identifier=https://orcid.org/0000-0000-0000-0001'
+      ]}
+    let(:identifiers_no_match) {[
+      'name=Test, Test; authority=ORCID; identifier=https://org/0000-0000-0000-0000', 
+      'name=Test1, Test1; authority=ORCID; identifier=https://org/0000-0000-0000-0001'
+      ]}
+    let(:identifiers_empty){[]}
+    it 'returns the author ORCID links if match patern' do
+      result = get_contributors(identifiers)
+      expect(result).to eq(['https://orcid.org/0000-0000-0000-0000', 'https://orcid.org/0000-0000-0000-0001'])
+    end
+
+    it 'returns nil if doesnt match patern' do
+      result = get_contributors(identifiers_no_match)
+      expect(result).to eq([])
+    end
+
+    it 'returns nil if identifiers empty' do
+      result = get_contributors(identifiers_no_match)
+      expect(result).to eq([])
+    end
+  end
+
+  describe '#object_items:read_master:true' do
+    
+    before do
+      # set behavior for necessary methods
+      allow_any_instance_of(DRI::Asset::MimeTypes).to receive(:pdf?).and_return(true, false)
+      allow_any_instance_of(DRI::Asset::MimeTypes).to receive(:text?).and_return(true, false)
+      allow_any_instance_of(DRI::Asset::MimeTypes).to receive(:threeD?).and_return(true, false)
+  
+      # Create a double for @document and set its behavior
+      @document = instance_double('Test')
+      # Create behavior based in the instance 
+      allow(@document).to receive(:read_master?).and_return(true)
+    end
+    
+    it 'returns one item array for a single asset PDF type' do
+      assets = [double("asset", "id" => "1", "mime_type_tesim" => ["application/pdf"])]
+
+      allow(assets[0]).to receive(:fetch).with("id", nil).and_return("1")
+      allow(assets[0]).to receive(:text?).and_return(true)
+      allow(assets[0]).to receive(:pdf?).and_return(true)
+      allow(assets[0]).to receive(:threeD?).and_return(false)
+      allow(assets[0]).to receive(:fetch).with(any_args).and_return("application/pdf")
+      
+      result = object_items(assets, id)
+      expect(result).to be_an(Array)
+      expect(result.size).to eq(1)
+      expect(result.first[:type]).to eq('application/pdf')
+    end
+
+    it 'returns two items array for a single asset TEXT type' do
+      assets = [double("asset", "id" => "1", "mime_type_tesim" => ["text/plain"])]
+      allow(assets[0]).to receive(:fetch).with("id", nil).and_return("1")
+      allow(assets[0]).to receive(:text?).and_return(true)
+      allow(assets[0]).to receive(:pdf?).and_return(true)
+      allow(assets[0]).to receive(:threeD?).and_return(false)
+      allow(assets[0]).to receive(:fetch).with(any_args).and_return("text/plain")
+      
+      result = object_items(assets, id)
+      expect(result).to be_an(Array)
+      expect(result.size).to eq(2)
+      expect(result.first[:type]).to eq('application/pdf')
+      expect(result.last[:type]).to eq('text/plain')
+    end
+
+    it 'returns one item array for a single asset 3D type' do
+      assets = [double("asset", "id" => "1", "mime_type_tesim" => ["glTF binary model"])]
+      allow(assets[0]).to receive(:fetch).with("id", nil).and_return("1")
+      allow(assets[0]).to receive(:text?).and_return(false)
+      allow(assets[0]).to receive(:pdf?).and_return(false)
+      allow(assets[0]).to receive(:threeD?).and_return(true)
+      allow(assets[0]).to receive(:fetch).with(any_args).and_return("glTF binary model")
+      
+      result = object_items(assets, id)
+      expect(result).to be_an(Array)
+      expect(result.size).to eq(1)
+      expect(result.first[:type]).to eq('glTF binary model')
+    end
+
+    it 'returns 3 items array for other types' do
+      assets = [
+        double("asset", "id" => "1", "mime_type_tesim" => ["audio/mp3"]),
+        double("asset", "id" => "2", "mime_type_tesim" => ["application/mp4"]),
+        double("asset", "id" => "3", "mime_type_tesim" => ["image/png"])
+      ]
+      allow(assets[0]).to receive(:fetch).with("id", nil).and_return("1")
+      allow(assets[0]).to receive(:text?).and_return(false)
+      allow(assets[0]).to receive(:pdf?).and_return(false)
+      allow(assets[0]).to receive(:threeD?).and_return(false)
+      allow(assets[0]).to receive(:fetch).with(any_args).and_return("audio/mp3")
+
+      allow(assets[1]).to receive(:fetch).with("id", nil).and_return("2")
+      allow(assets[1]).to receive(:text?).and_return(false)
+      allow(assets[1]).to receive(:pdf?).and_return(false)
+      allow(assets[1]).to receive(:threeD?).and_return(false)
+      allow(assets[1]).to receive(:fetch).with(any_args).and_return("application/mp4")
+
+      allow(assets[2]).to receive(:fetch).with("id", nil).and_return("3")
+      allow(assets[2]).to receive(:text?).and_return(false)
+      allow(assets[2]).to receive(:pdf?).and_return(false)
+      allow(assets[2]).to receive(:threeD?).and_return(false)
+      allow(assets[2]).to receive(:fetch).with(any_args).and_return("image/png")
+      
+      result = object_items(assets, id)
+      expect(result).to be_an(Array)
+      expect(result.size).to eq(3)
+      expect(result[0][:type]).to eq('audio/mp3')
+      expect(result[1][:type]).to eq('application/mp4')
+      expect(result[2][:type]).to eq('image/png')
+    end
+
+  end
+
+  describe '#object_items:read_master:false' do
+    
+    before do
+      allow_any_instance_of(DRI::Asset::MimeTypes).to receive(:pdf?).and_return(true, false)
+      allow_any_instance_of(DRI::Asset::MimeTypes).to receive(:text?).and_return(true, false)
+      allow_any_instance_of(DRI::Asset::MimeTypes).to receive(:threeD?).and_return(true, false)
+  
+      @document = instance_double('Test')
+      allow(@document).to receive(:read_master?).and_return(false)
+    end
+
+    it 'returns one item array for a single asset PDF type' do
+      assets = [double("asset", "id" => "1", "mime_type_tesim" => ["application/pdf"])]
+      allow(assets[0]).to receive(:fetch).with("id", nil).and_return("1")
+      allow(assets[0]).to receive(:text?).and_return(true)
+      allow(assets[0]).to receive(:pdf?).and_return(true)
+      allow(assets[0]).to receive(:threeD?).and_return(false)
+      allow(assets[0]).to receive(:fetch).with(any_args).and_return("application/pdf")
+      
+      result = object_items(assets, id)
+      expect(result).to be_an(Array)
+      expect(result.size).to eq(1)
+      expect(result.first[:type]).to eq('application/pdf')
+    end
+
+    it 'returns one item array for a single asset TEXT type' do
+      assets = [double("asset", "id" => "1", "mime_type_tesim" => ["text/plain"])]
+      allow(assets[0]).to receive(:fetch).with("id", nil).and_return("1")
+      allow(assets[0]).to receive(:text?).and_return(true)
+      allow(assets[0]).to receive(:pdf?).and_return(true)
+      allow(assets[0]).to receive(:threeD?).and_return(false)
+      allow(assets[0]).to receive(:fetch).with(any_args).and_return("text/plain")
+      
+      result = object_items(assets, id)
+      expect(result).to be_an(Array)
+      expect(result.size).to eq(1)
+      expect(result.first[:type]).to eq('application/pdf')
+    end
+
+    it 'returns one item array for a single asset 3D type' do
+      assets = [double("asset", "id" => "1", "mime_type_tesim" => ["glTF binary model"])]
+      allow(assets[0]).to receive(:fetch).with("id", nil).and_return("1")
+      allow(assets[0]).to receive(:text?).and_return(false)
+      allow(assets[0]).to receive(:pdf?).and_return(false)
+      allow(assets[0]).to receive(:threeD?).and_return(true)
+      allow(assets[0]).to receive(:fetch).with(any_args).and_return("glTF binary model")
+      
+      result = object_items(assets, id)
+      expect(result).to be_an(Array)
+      expect(result.size).to eq(1)
+      expect(result.first[:type]).to eq('glTF binary model')
+    end
+
+    it 'returns 3 items array for other types' do
+      assets = [
+        double("asset", "id" => "1", "mime_type_tesim" => ["audio/mp3"]),
+        double("asset", "id" => "2", "mime_type_tesim" => ["application/mp4"]),
+        double("asset", "id" => "3", "mime_type_tesim" => ["image/png"])
+      ]
+      allow(assets[0]).to receive(:fetch).with("id", nil).and_return("1")
+      allow(assets[0]).to receive(:text?).and_return(false)
+      allow(assets[0]).to receive(:pdf?).and_return(false)
+      allow(assets[0]).to receive(:threeD?).and_return(false)
+      allow(assets[0]).to receive(:fetch).with(any_args).and_return("audio/mp3")
+
+      allow(assets[1]).to receive(:fetch).with("id", nil).and_return("2")
+      allow(assets[1]).to receive(:text?).and_return(false)
+      allow(assets[1]).to receive(:pdf?).and_return(false)
+      allow(assets[1]).to receive(:threeD?).and_return(false)
+      allow(assets[1]).to receive(:fetch).with(any_args).and_return("application/mp4")
+
+      allow(assets[2]).to receive(:fetch).with("id", nil).and_return("3")
+      allow(assets[2]).to receive(:text?).and_return(false)
+      allow(assets[2]).to receive(:pdf?).and_return(false)
+      allow(assets[2]).to receive(:threeD?).and_return(false)
+      allow(assets[2]).to receive(:fetch).with(any_args).and_return("image/png")
+      
+      result = object_items(assets, id)
+      expect(result).to be_an(Array)
+      expect(result.size).to eq(3)
+      expect(result[0][:type]).to eq('audio/mp3')
+      expect(result[1][:type]).to eq('application/mp4')
+      expect(result[2][:type]).to eq('image/png')
+    end
+
+  end
+
+  describe '#metadata_link' do
+
+    before do
+      @document = { 'has_model_ssim' => ['DRI::QualifiedDublinCore'] }
+      allow_any_instance_of(SignpostingHeaderHelper).to receive(:mapped_links).and_return(nil)
+    end
+
+
+    it 'returns the correct metadata link without profile' do
+      result = metadata_link(id)
+
+      expect(result[:href]).to eq("http://repository.dri.ie/objects/#{id}/metadata")
+      expect(result[:type]).to eq('application/xml')
+      expect(result[:profile]).to be_nil
+    end
+
+    it 'returns the correct metadata link with profile' do
+      allow_any_instance_of(SignpostingHeaderHelper).to receive(:mapped_links).and_return('http://test.com/profile')
+      
+      result = metadata_link(id)
+
+      expect(result[:href]).to eq("http://repository.dri.ie/objects/#{id}/metadata")
+      expect(result[:type]).to eq('application/xml')
+      expect(result[:profile]).to eq('http://test.com/profile')
+    end
+  end
+
+  describe '#reverse_link_builder' do
+    let(:ancestor_id) { ['ancestor_id'] }
+    let(:object_id) { 'object_id' }
+
+    it 'returns an array of reverse links' do
+      link_assets = [
+        { 'href1' => 'link1' },
+        { 'href2' => 'link2' }
+      ]
+
+      result = reverse_link_builder(link_assets, ancestor_id, object_id)
+
+      expect(result).to be_an(Array)
+      expect(result.size).to eq(2)
+
+      expect(result[0][:anchor]).to eq('link1')
+      expect(result[0][:collection]).to be_an(Array)
+      expect(result[0][:collection].size).to eq(1)
+      expect(result[0][:collection][0][:href]).to eq("https://repository.dri.ie/catalog/#{ancestor_id.first}")
+      expect(result[0][:collection][0][:type]).to eq('text/html')
+
+      expect(result[1][:anchor]).to eq('link2')
+      expect(result[1][:collection]).to be_an(Array)
+      expect(result[1][:collection].size).to eq(1)
+      expect(result[1][:collection][0][:href]).to eq("https://repository.dri.ie/catalog/#{ancestor_id.first}")
+      expect(result[1][:collection][0][:type]).to eq('text/html')
+    end
+
+  end
+
+end

--- a/spec/helpers/signposting_header_helper_spec.rb
+++ b/spec/helpers/signposting_header_helper_spec.rb
@@ -255,7 +255,7 @@ RSpec.describe SignpostingHeaderHelper, type: :helper do
     it 'returns the correct metadata link without profile' do
       result = metadata_link(id)
 
-      expect(result[:href]).to eq("http://repository.dri.ie/objects/#{id}/metadata")
+      expect(result[:href]).to eq("https://repository.dri.ie/objects/#{id}/metadata")
       expect(result[:type]).to eq('application/xml')
       expect(result[:profile]).to be_nil
     end
@@ -265,7 +265,7 @@ RSpec.describe SignpostingHeaderHelper, type: :helper do
       
       result = metadata_link(id)
 
-      expect(result[:href]).to eq("http://repository.dri.ie/objects/#{id}/metadata")
+      expect(result[:href]).to eq("https://repository.dri.ie/objects/#{id}/metadata")
       expect(result[:type]).to eq('application/xml')
       expect(result[:profile]).to eq('http://test.com/profile')
     end


### PR DESCRIPTION
Implementing FAIR Signposting level 2 link-set (objects)

At this stage the linksets were implemented at Object level:
![image](https://github.com/Digital-Repository-of-Ireland/dri-app/assets/115575268/c9315ee4-6d86-40b3-8a37-baecb0f2c51c)
Image 1: highlighted target implementation, object tier

Links for the new linkset are visible at the <head> of the webpage, in the format below:

```
<head>
...
<link href="http://repository.dri.ie/linkset/#{obj_id}/json" rel="linkset" type="application/linkset+json">
<link href="http://repository.dri.ie/linkset/#{obj_id}/lset" rel="linkset" type="application/linkset">
...
</head>
```

The request hits one of the two new controllers created to serve each answer format "application/linkset" and "aplication/linkset+json"

- signposting_header_lset_controller.rb
- signposting_header_lset_json_controller.rb

The controllers depends on signposting_header_helper.rb to verify if object_id is valid, make solr requests and work the data, optimizing the code due to the similarity of the two controllers needs.

![image](https://github.com/Digital-Repository-of-Ireland/dri-app/assets/115575268/952da009-8654-406d-8256-db6b0fd139ce)
Image 2: request workflow

The answer structure is based on https://signposting.org/FAIR/#level2a

![image](https://github.com/Digital-Repository-of-Ireland/dri-app/assets/115575268/6e225d64-d9fa-487e-abd1-b7f2c500a509)
Image 3: answer structure

Running tests: bundle exec rspec spec/helpers/signposting_header_helper_spec.rb
![image](https://github.com/Digital-Repository-of-Ireland/dri-app/assets/115575268/74e7f7d6-5d74-41e2-baf5-9dfd1ca8d126)