### PR TITLE
Citation Format

### DIFF
--- a/app/helpers/citations_helper.rb
+++ b/app/helpers/citations_helper.rb
@@ -2,19 +2,60 @@
 module CitationsHelper
   include DRI::CitationsBehaviours::NameBehaviour
 
+  STYLE_AND_FORMAT = {
+    apa: { style: 'apa', format: 'text' },
+    chicago: { style: 'chicago-note-bibliography', format: 'text' },
+    mla: { style: 'modern-language-association', format: 'text' }
+  }.freeze
+  DRI_STRING = 'Digital Repository of Ireland'.freeze
+  DEPOSITOR_STRING = '[Depositor]'.freeze
+  PUBLISHER_STRING = '[Publisher]'.freeze
+  TYPE_STRING = '[Type]'.freeze
+  ACCESS_DATE_STRING = "(Accessed: #{Time.current.strftime('%Y/%m/%d')})".freeze
+  COLLECTION_STRING = 'Collection'.freeze
+  DOI_PRE_LINK = 'https://doi.org/'.freeze
+
   def export_as_apa_citation(object, doi = nil, depositing_institute = nil)
-    cp = CiteProc::Processor.new style: 'apa', format: 'text'
-    render_citation(cp, object, doi, depositing_institute)
+    render_citation(STYLE_AND_FORMAT[:apa], object, doi, depositing_institute)
   end
 
   def export_as_chicago_citation(object, doi = nil, depositing_institute = nil)
-    cp = CiteProc::Processor.new style: 'chicago-note-bibliography', format: 'text'
-    render_citation(cp, object, doi, depositing_institute)
+    render_citation(STYLE_AND_FORMAT[:chicago], object, doi, depositing_institute)
   end
 
   def export_as_mla_citation(object, doi = nil, depositing_institute = nil)
-    cp = CiteProc::Processor.new style: 'modern-language-association', format: 'text'
-    render_citation(cp, object, doi, depositing_institute)
+    render_citation(STYLE_AND_FORMAT[:mla], object, doi, depositing_institute)
+  end
+
+  # TODO: Update Tests
+  def export_as_dri_citation_dri_general(object, doi = nil, depositing_institute = nil)
+    citation_parts = []
+    add_depositor(citation_parts)
+    add_published_date(citation_parts, object)
+    add_title(citation_parts, object)
+    add_creator(citation_parts, object, depositing_institute, false)
+    add_temporal_coverage(citation_parts, object)
+    add_type(citation_parts, object, ObjectsController::PrimaryTypes::TYPES)
+    add_publiser(citation_parts, object)
+    add_system_gen_date(citation_parts, object)
+    add_doi(citation_parts, doi)
+    add_current_date(citation_parts)
+    citation_parts.join(" ")
+  end
+
+  def export_as_dri_citation_dri_research(object, doi = nil, depositing_institute = nil)
+    citation_parts = []
+    add_creator(citation_parts, object, depositing_institute, false)
+    add_creation_date(citation_parts, object)
+    add_title(citation_parts, object)
+    add_type(citation_parts, object, ObjectsController::PrimaryTypes::TYPES)
+    add_publiser(citation_parts, object)
+    add_system_gen_date(citation_parts, object)
+    add_depositor_res(citation_parts, depositing_institute)
+    add_doi(citation_parts, doi)
+    add_current_date(citation_parts)
+  
+    citation_parts.join(" ")
   end
 
   def to_citeproc(object, doi = nil, depositing_institute = nil)
@@ -23,7 +64,8 @@ module CitationsHelper
       id: object.alternate_id,
       title: object.title.join('. '),
       author: get_authors(object.creator),
-      'container-title' => 'Digital Repository of Ireland'
+      'container-title' => 'Digital Repository of Ireland',
+      # Including the string "test" in a custom field
     }
     csl_hash[:DOI] = doi if doi
     csl_hash[:issued] = object.published_at if object.published_at.present?
@@ -32,8 +74,80 @@ module CitationsHelper
     JSON.dump(csl_hash)
   end
 
-  def render_citation(citeproc_processor, object, doi = nil, depositing_institute = nil)
+  def render_citation(style_and_format, object, doi = nil, depositing_institute = nil)
+    cp = CiteProc::Processor.new(style_and_format)
+    render_csl(cp, object, doi, depositing_institute)
+  end
+
+  def render_csl(citeproc_processor, object, doi = nil, depositing_institute = nil)
     citeproc_processor.import([to_citeproc(object, doi, depositing_institute)])
     citeproc_processor.render(:bibliography, id: object.alternate_id).first
+  end
+
+  private
+  def add_depositor(citation_parts)
+    citation_parts << DRI_STRING
+  end
+
+  def add_depositor_res(citation_parts, depositing_institute)
+    citation_parts << "#{depositing_institute} #{DEPOSITOR_STRING}" if depositing_institute.to_s.strip.present?
+  end
+
+  def add_published_date(citation_parts, object)
+    date = object.published_date.reject(&:empty?).first || object.date.reject(&:empty?).first || object.creation_date.reject(&:empty?).first
+    citation_parts << (date.present? ? "(#{date})#{DEPOSITOR_STRING}" : DEPOSITOR_STRING)
+  end
+
+  def add_title(citation_parts, object)
+    citation_parts << "#{object.title.join('. ')}." if object.title.to_s.strip.present?
+  end
+
+  def add_creator(citation_parts, object, depositing_institute, researsher)
+    object.creator.each_with_index do |creator, index|
+      if depositing_institute != creator || researsher
+        citation_parts << "#{creator}#{index == object.creator.size - 1 ? '.' : ','}"
+      end
+    end
+  end
+
+  def add_temporal_coverage(citation_parts, object)
+    citation_parts << "(#{object.temporal_coverage.first})" if object.temporal_coverage.first.present?
+  end
+
+  def add_type(citation_parts, object, primeTypes)
+    type = object.type.find { |x| primeTypes.include?(x.downcase.delete(' ')) || x == COLLECTION_STRING }
+    type ||= object.type.first
+    citation_parts << "#{type} #{TYPE_STRING}" if type.to_s.strip.present?
+  end
+
+  def add_publiser(citation_parts, object)
+    citation_parts << (object.publisher.present? ? "#{object.publisher}" : DRI_STRING)
+  end
+
+  def add_system_gen_date(citation_parts, object)
+    if object.published_at.present?
+      begin
+        formatted_date = DateTime.parse(object.published_at).strftime('%Y')
+        citation_parts << "(#{formatted_date}) #{PUBLISHER_STRING}"
+      rescue ArgumentError => e
+        puts "Error parsing date: #{e.message}"
+      end
+    elsif object.published_date.first.present?
+      citation_parts << "(#{object.published_date.first}) #{PUBLISHER_STRING}"
+    else
+      citation_parts << PUBLISHER_STRING
+    end
+  end
+
+  def add_doi(citation_parts, doi)
+    citation_parts << "#{DOI_PRE_LINK}#{doi}" if doi.to_s.strip.present?
+  end
+
+  def add_current_date(citation_parts)
+    citation_parts << ACCESS_DATE_STRING
+  end
+
+  def add_creation_date(citation_parts, object)
+    citation_parts << "(#{object.date.first})" if object.date.first.to_s.strip.present?
   end
 end

--- a/app/models/concerns/dri/solr/document/metadata.rb
+++ b/app/models/concerns/dri/solr/document/metadata.rb
@@ -50,6 +50,14 @@ module DRI::Solr::Document
       metadata('type')
     end
 
+    def temporal_coverage
+      metadata('temporal_coverage')
+    end
+
+    def publisher
+      metadata("publisher")
+    end
+
     def extract_metadata(metadata_fields)
       item = {}
 

--- a/app/views/objects/_citation.html.erb
+++ b/app/views/objects/_citation.html.erb
@@ -6,12 +6,13 @@
 	<textarea id="citation-text-apa" class="dri_clipboard_text" cols="62" rows="6" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" readonly="readonly" style="display:none"><%= export_as_apa_citation(@object, @doi.presence, @depositing_institute.presence) %></textarea>
     <textarea id="citation-text-chicago" class="dri_clipboard_text" cols="62" rows="6" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" readonly="readonly" style="display:none"><%= export_as_chicago_citation(@object, @doi.presence, @depositing_institute.presence) %></textarea>
     <textarea id="citation-text-mla" class="dri_clipboard_text" cols="62" rows="6" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" readonly="readonly" style="display:none"><%= export_as_mla_citation(@object, @doi.presence, @depositing_institute.presence) %></textarea>
-    <textarea id="citation-text-dri" class="dri_clipboard_text" cols="62" rows="6" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" readonly="readonly"><%= @object.export_as_dri_citation %><% if @doi.present? %><%= ", https://doi.org/#{@doi}" %><% end %></textarea>
+    <textarea id="citation-text-dri-res" class="dri_clipboard_text" cols="62" rows="6" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" readonly="readonly" style="display:none"><%= export_as_dri_citation_dri_research(@object, @doi.presence, @depositing_institute.presence) %></textarea>
+    <textarea id="citation-text-dri-gen" class="dri_clipboard_text" cols="62" rows="6" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false" readonly="readonly"><%= export_as_dri_citation_dri_general(@object, @doi.presence, @depositing_institute.presence) %></textarea>
 </div>
 <div class="modal-footer">
   <b><%= t('dri.views.catalog.legends.citation_style') %>:&nbsp;</b>
   <select id="dri_citation_options_id" class="dri_citation_options" name="citation_options">
-     <% %w[dri apa chicago mla].each do |style| %>
+     <% %w[dri-gen dri-res apa chicago mla].each do |style| %>
      <option value="<%= style %>"><%= style %></option>
       <%- end -%>
   </select>


### PR DESCRIPTION
PR based on [DRI Citation Format Review 2024](https://docs.google.com/document/d/1zbaKnDJM88aF74PnVLcpFjP2Mt0biAo_ecbCePx_JBU/edit)

When user clicks on "Cite" at the side toolbar (objects or collections) there are 2 fresh options "dri-gen" & "dri-res".
Note 1: Names can be changed as required, my only advice is to keep short if possible as it may affect the layout of the modal.
Note 2: General citation is pre-selected as standard.

![image](https://github.com/Digital-Repository-of-Ireland/dri-app/assets/115575268/82d37028-0d26-4fda-84b1-50ecf560f8a9)
_**Image 1:** Modal citation options._

**export_as_dri_citation_dri_general**
![image](https://github.com/Digital-Repository-of-Ireland/dri-app/assets/115575268/f7e95f81-e6e3-4d18-8c2a-36e14bb44ed9)

**export_as_dri_citation_dri_research**
![image](https://github.com/Digital-Repository-of-Ireland/dri-app/assets/115575268/bc253bfa-5c4a-48fa-a132-142e33bba2e8)

Test cases:

DRI_2 "UseCase r3" Collection
![image](https://github.com/Digital-Repository-of-Ireland/dri-app/assets/115575268/75a5db0e-b763-4a8a-ac66-cd0525bc87fb)

DRI_1 "UseCase r1" Collection
![image](https://github.com/Digital-Repository-of-Ireland/dri-app/assets/115575268/54c7427b-e1b2-4d54-8038-b184cb18881e)

DRI_1 "UseCase" 2 Object
![image](https://github.com/Digital-Repository-of-Ireland/dri-app/assets/115575268/fb127135-6f66-4be7-823a-21ced6604ed7)

