### PR TITLE
Fix Embedded 3D

### DIFF
--- a/app/assets/javascripts/three_js_viewer_embed.js
+++ b/app/assets/javascripts/three_js_viewer_embed.js
@@ -1,0 +1,177 @@
+$(document).ready(function () {
+    $('.three_js_viewer_embed').each(function () {
+        var element = $(this);
+        var url = element.data('url');
+        var file = element.data('file');
+        var id = String(element.attr('id'));
+        var extension = file.split('.').pop().toLowerCase();
+
+        var container = document.createElement('div');
+
+        var parentDiv = document.getElementById(String(element.attr('id')));
+        parentDiv.appendChild(container);
+
+        var scene = new THREE.Scene();
+        var camera = new THREE.PerspectiveCamera(
+            50, 
+            window.innerWidth / window.innerHeight, 
+            0.1, 
+            5000
+        );
+
+        // Set Normal material
+        const normalMaterial = new THREE.MeshNormalMaterial({
+            wireframe: false,
+            flatShading: false,
+            transparent: false
+        });
+
+        // Set a larger canvas size
+        var canvasWidth = 560;
+        var canvasHeight = 315;
+
+        var renderer = new THREE.WebGLRenderer();
+        renderer.setSize(canvasWidth, canvasHeight);
+        parentDiv.appendChild(renderer.domElement);
+
+        var controls = new THREE.OrbitControls(camera, renderer.domElement);
+
+        function handleError(fileType, error) {
+            console.error(`Error loading ${fileType} file:`, error);
+        }
+
+        switch(extension) {
+            case 'stl':
+                var loader = new THREE.STLLoader();
+                loader.load(url, function (geometry) {
+                    var mesh = new THREE.Mesh(geometry);
+                    processObject(mesh);
+                    scene.add(mesh);
+                    setCamera(mesh);
+                    animate();
+                }, undefined, handleError.bind(null, 'STL'));
+                break;
+
+            case 'ply':
+                var loader = new THREE.PLYLoader();
+                loader.load(url, function (geometry) {
+                    geometry.computeVertexNormals();
+                    var mesh = new THREE.Mesh(geometry);
+                    processObject(mesh)
+                    scene.add(mesh);
+                    setCamera(mesh);
+                    animate();
+                    }, undefined, handleError.bind(null, 'PLY'));
+                    break;
+
+            case 'glb':
+            case 'gltf':
+                const dracoLoader = new THREE.DRACOLoader();
+                dracoLoader.setDecoderPath('https://www.gstatic.com/draco/versioned/decoders/1.4.1/');
+                dracoLoader.setDecoderConfig({ type: 'js' });
+                const gltfLoader = new THREE.GLTFLoader();
+                gltfLoader.setDRACOLoader(dracoLoader);
+                gltfLoader.load(
+                    url,
+                    function (gltf) {
+                        var sceneModel = gltf.scene;
+                        processObject(sceneModel)
+                        scene.add(sceneModel);
+                        setCamera(sceneModel);
+                        animate();
+                    }, undefined, handleError.bind(null, 'GLTF'));
+                    break;
+            
+            case 'fbx':
+                var loader = new THREE.FBXLoader();
+                loader.load(url, function (object) {
+                    processObject(object)
+                    scene.add(object);
+                    setCamera(object);
+                    animate();
+                }, undefined, handleError.bind(null, 'FBX'));
+                break;
+                    
+            case 'obj':
+                var loader = new THREE.OBJLoader();
+                loader.load(url, function (object) {
+                    processObject(object)
+                    scene.add(object);
+                    setCamera(object);
+                    animate();
+                }, undefined, handleError.bind(null, 'OBJ'));
+                break;
+                    
+            case 'dae':
+                var loader = new THREE.ColladaLoader();
+                loader.load(url, function (collada) {
+                    var object = collada.scene;
+                    if (object.children.length > 0) {
+                        var mesh = object.children[0];
+                        processObject(mesh);
+                        scene.add(mesh);
+                        setCamera(mesh);
+                        animate();
+                    } else {
+                        console.error('No child meshes found.');
+                    }
+                }, undefined, handleError.bind(null, 'DAE'));
+                break;
+        
+            default:
+                console.error('Error loading 3D file:', error);
+        }
+
+        var animate = function () {
+            requestAnimationFrame(animate);
+            controls.update();
+            renderer.render(scene, camera);
+        };
+
+        function processObject(object) {
+            try {
+                object.traverse(function (child) {
+                    if (child.isMesh) {
+                        child.material = normalMaterial;
+                    }
+                });
+        
+                // If the object is an FBX model, convert its coordinate system from Z-up to Y-up
+                if (object.isFBX === true) {
+                    object.rotation.x = -Math.PI / 2;
+                }
+
+            } catch (error) {
+                console.error('An error occurred while processing the object:', error);
+            }
+        }
+
+        if (scene.background === null || scene.background === undefined ) {
+            var backgroundColour = new THREE.Color(0xd8d8d8);
+            scene.background = new THREE.Color( backgroundColour );
+        }
+
+        function setCamera(object) {
+            const boundingBox = new THREE.Box3().setFromObject(object);
+            const boxSize = new THREE.Vector3();
+            boundingBox.getSize(boxSize);
+        
+            // Calculate the distance from the object based on its size
+            const distance = Math.max(boxSize.x, boxSize.y, boxSize.z) * 2;
+        
+            // Position the camera at a fixed distance from the object
+            camera.position.set(0, 0, distance);
+        
+            // Set the camera target (center of the object)
+            cameraTarget = boundingBox.getCenter(new THREE.Vector3());
+        
+            // Update the camera's near and far clipping planes
+            const near = distance / 100;
+            const far = distance * 100;
+            camera.near = near;
+            camera.far = far;
+            camera.updateProjectionMatrix();
+        };
+        
+    });
+});

--- a/app/assets/stylesheets/sass/dri/dri_layouts.scss
+++ b/app/assets/stylesheets/sass/dri/dri_layouts.scss
@@ -80,6 +80,14 @@
  height: 1024px;
  margin: auto;   
 }
+#gui{
+    .dg{
+        height: 80% !important;
+      }
+    .main{
+        height: 80% !important;
+    }
+}
 
 .dri_main_content_container {
     @include zen-grid-item(4, 1);

--- a/app/assets/stylesheets/sass/dri/modules/_dri_object.scss
+++ b/app/assets/stylesheets/sass/dri/modules/_dri_object.scss
@@ -147,8 +147,9 @@ h2.dri_no_asset_availiable {
     z-index: 10;
     opacity: 75%;
     width: fit-content;
+    height: 80%;
     
-    .dg .c input[type="text"] {
+    .dg .main .c input[type="text"] {
         border: 0;
         margin-top: 0px;
         padding: 0px;

--- a/app/views/embed3d/show.html.erb
+++ b/app/views/embed3d/show.html.erb
@@ -3,7 +3,7 @@
     <% if @generic_file.threeD? %>
       <% @surrogate = file_download_path(@document.id, @generic_file.id, type: 'masterfile') %>
 
-      <%= render partial: 'shared/display_3d', locals: { url: @surrogate  } %>
+      <%= render partial: 'shared/display_3d_embed', locals: { id:@generic_file.id ,url: @surrogate, generic_file_name: @generic_file.label} %>
     <% end %>
 
     <% if @surrogate.blank? %>

--- a/app/views/shared/_carousel_item.html.erb
+++ b/app/views/shared/_carousel_item.html.erb
@@ -106,9 +106,9 @@
           (generic_file.threeD? || !document.read_master?) %> <%# Change conditions when 3D surrogate is available%>
       <%= t('dri.views.catalog.links.download_not_available', index: generic_file_counter.ordinalize) %>
     <% elsif document.read_master? || @surrogate && can?(:read, document.id) || can?(:edit, document.id) %>
-      <%# if generic_file.threeD? %>
-        <%#= link_to t('dri.views.catalog.links.embed_data'), { controller: 'api/oembed', action: 'show', url: catalog_url }, class: 'dri_embed_link' %> <%# Embed link not working for 3D assets %>
-      <%# end %>
+      <% if generic_file.threeD? %>
+        <%= link_to t('dri.views.catalog.links.embed_data'), { controller: 'api/oembed', action: 'show', url: catalog_url, asset_id: generic_file.id }, class: 'dri_embed_link' %>
+      <% end %>
       <%= link_to '#dri_download_modal_id', :'data-bs-toggle' => 'modal', :'data-fileid' => generic_file.id, :id => "configure_download_#{generic_file.id}", class: 'configure_download' do %>
         <%= t('dri.views.catalog.links.download') %>
       <% end %>

--- a/app/views/shared/_display_3d_embed.erb
+++ b/app/views/shared/_display_3d_embed.erb
@@ -1,0 +1,7 @@
+<% content_for :head do %>
+    <%= javascript_include_tag 'three_js_viewer_embed', async: Rails.env.production? %>
+<% end %>
+
+<%= content_tag('div', class: "three_js_viewer_embed", id: "dri_threejs_view #{id}" , data: { id: id, url: url, file: generic_file_name}) do %>
+
+<% end %>

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -13,6 +13,7 @@ Rails.application.config.assets.paths << Rails.root.join('node_modules')
 #%w( Three/dat.gui.min.js )
 #]	
 
+Rails.application.config.assets.precompile += %w( three_js_viewer_embed.js )
 
 # Precompile additional assets.
 # application.js, application.css, and all non-JS/CSS in the app/assets


### PR DESCRIPTION
The Embedded 3D feature allow the 3D assets to be shared under limited configuration.
Skins, images, and textures are overwritten by NormalMaterial allowing better visualization independent on other parameters as light/shadow.
The response format is kept as the width and height (560 x 315).

![image](https://github.com/Digital-Repository-of-Ireland/dri-app/assets/115575268/868a779f-16fb-4409-8a6c-594e2b0ca705)
Image: embedded view

Note: The "Embed" button present in the left side of the carousel viewer is not correctly generating links to specific 3D object when there are more than a single 3D file. This issue shall be directed in future PR. Additionally,  viewer controls can be implemented in the next PR's as well.
 