### PR TITLE
Added strings to en.yml

### DIFF
--- a/app/assets/stylesheets/sass/dri/_dri.scss
+++ b/app/assets/stylesheets/sass/dri/_dri.scss
@@ -380,6 +380,37 @@ input.dri_w230 {
 }
 /*-------------- Signin Error message styling --------------*/
 
+div.error_page {
+    background-color: $dri_white;
+    color: $dri_darkgrey;
+    text-align: center;
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+  
+
+    main {
+      width: 90%;
+      padding: 2em;
+      margin: 4em auto;
+      border: 1px solid $dri_extralightgrey;
+      border-right-color: $dri_extralightgrey;
+      border-bottom-color: $dri_extralightgrey;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    }
+
+    h1 {
+      font-size: 24px;
+      color: $dri_red;
+      margin-bottom: 1em;
+    }
+
+    p {
+      font-size: 18px;
+      color: $dri_black;
+    }
+  }
+
 .dri_login_form_block .field_with_errors {
     background-color: $dri_white;
 }

--- a/app/views/error/404.html.erb
+++ b/app/views/error/404.html.erb
@@ -1,26 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>The page you were looking for doesn't exist (404)</title>
-  <style type="text/css">
-      body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
-      div.dialog {
-          width: 25em;
-          padding: 0 4em;
-          margin: 4em auto 0 auto;
-          border: 1px solid #ccc;
-          border-right-color: #999;
-          border-bottom-color: #999;
-      }
-      h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
-  </style>
-</head>
-
-<body>
-<!-- This file lives in public/404.html -->
-<div class="dialog">
-  <h1>The page you were looking for doesn't exist.</h1>
-  <p>You may have mistyped the address or the page may have moved.</p>
+<div class="error_page">
+  <main class="dialog" role="main">
+    <h1 aria-live="assertive"><%= t('dri.server_error.404_error')%></h1>
+    <h1 aria-live="assertive"><%= t('dri.server_error.404_message')%></h1>
+    <p><%= t('dri.server_error.404_explanation')%></p>
+  </main>
 </div>
-</body>
-</html>

--- a/app/views/error/422.html.erb
+++ b/app/views/error/422.html.erb
@@ -1,26 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>The change you wanted was rejected (422)</title>
-  <style type="text/css">
-      body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
-      div.dialog {
-          width: 25em;
-          padding: 0 4em;
-          margin: 4em auto 0 auto;
-          border: 1px solid #ccc;
-          border-right-color: #999;
-          border-bottom-color: #999;
-      }
-      h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
-  </style>
-</head>
-
-<body>
-<!-- This file lives in public/422.html -->
-<div class="dialog">
-  <h1>The change you wanted was rejected.</h1>
-  <p>Maybe you tried to change something you didn't have access to.</p>
-</div>
+<body class="error_page">
+  <main class="dialog" role="main">
+    <h1 aria-live="assertive"><%= t('dri.server_error.422_error') %></h1>
+    <h1 aria-live="assertive"><%= t('dri.server_error.422_message') %></h1>
+    <p><%= t('dri.server_error.422_explanation') %></p>
+  </main>
 </body>
-</html>

--- a/app/views/error/500.html.erb
+++ b/app/views/error/500.html.erb
@@ -1,25 +1,7 @@
-<!DOCTYPE html>
-<html>
-<head>
-  <title>We're sorry, but something went wrong (500)</title>
-  <style type="text/css">
-      body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
-      div.dialog {
-          width: 25em;
-          padding: 0 4em;
-          margin: 4em auto 0 auto;
-          border: 1px solid #ccc;
-          border-right-color: #999;
-          border-bottom-color: #999;
-      }
-      h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
-  </style>
-</head>
-
-<body>
-<!-- This file lives in public/500.html -->
-<div class="dialog">
-  <h1>We're sorry, but something went wrong.</h1>
-</div>
+<body class="error_page">
+  <main class="dialog" role="main">
+    <h1 aria-live="assertive"><%= t('dri.server_error.500_error') %></h1>
+    <h1 aria-live="assertive"><%= t('dri.server_error.500_message') %></h1>
+    <p><%= t('dri.server_error.500_explanation') %></p>
+  </main>
 </body>
-</html>

--- a/app/views/institutes/index.html.erb
+++ b/app/views/institutes/index.html.erb
@@ -2,19 +2,19 @@
 <% style='' %>
 
 <h1 class="h3"><%= t('dri.views.collection.institute.title') %></h1>
-<p class="dri_orgs_legend"><%= t('dri.views.institutes.orgs_legend', url: 'http://www.dri.ie/membership').html_safe %></p>
+<p class="dri_orgs_legend"><%= t('dri.views.institutes.orgs_legend', url: t('dri.headerlinks.membership_link')).html_safe %></p>
 <div class="dri_section_block">
 <% @institutes.each_with_index do |institute, i| %>
   <% collection_count = @collections[institute.id].size %>
   <% next unless collection_count > 0 %>
   
-  <article role="article" class="dri_collection_institutes_pages <%= style %>" aria-label='Explore Collections of ' + <%= institute[:name].to_s.html_safe%>' %>
+  <article role="article" class="dri_collection_institutes_pages <%= style %>" aria-label= "<%= t('dri.views.institutes.org_aria_label')%> <%= institute[:name].to_s.html_safe%>" %>
     <% style = 'not_first' %>
     
     <% institute_browse_params[:f] = { institute_sim: [institute[:name].to_s.mb_chars.downcase.html_safe] } %>
-    <%= link_to main_app.search_catalog_path(institute_browse_params), 'aria-label' => 'Explore Collections of ' + institute[:name].to_s.html_safe do %>
+    <%= link_to main_app.search_catalog_path(institute_browse_params), 'aria-label' => t('dri.views.institutes.org_aria_label') + institute[:name].to_s.html_safe do %>
       <div class="dri_collection_institutes_pages_img" aria-hidden="true">
-        <%= image_tag logo_url(institute), alt: "institute " + institute[:name].to_s.html_safe + " logo" if institute.brand %>
+        <%= image_tag logo_url(institute), alt: institute[:name].to_s.html_safe + " " + t('dri.views.licences.forms.logo') if institute.brand %>
         <p>
           <%= institute[:name].to_s.html_safe %>
         </p>  
@@ -28,9 +28,9 @@
               <% present(collection, DRI::ImagePresenter) do |images| %>
                 <% image = images.cover_image %>
                 <% if image %>
-                  <li><%= image_tag image, title: collection[:title_tesim].first , alt:"Collection " + collection[:title_tesim].first.to_s.html_safe + "cover pic" %></li>
+                  <li><%= image_tag image, title: collection[:title_tesim].first , alt: t('dri.headerlinks.collection') + " " + collection[:title_tesim].first.to_s.html_safe %></li>
                 <% else %>
-                  <li><%= image_tag "no_image.png", title: collection[:title_tesim].first, alt:"Collection " + collection[:title_tesim].first.to_s.html_safe + "has no cover" %></li>
+                  <li><%= image_tag "no_image.png", title: collection[:title_tesim].first, alt: t('dri.headerlinks.collection') + " "  + collection[:title_tesim].first.to_s.html_safe %></li>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/views/shared/_form_metadata_qualifieddublincore.html.erb
+++ b/app/views/shared/_form_metadata_qualifieddublincore.html.erb
@@ -12,7 +12,7 @@
 		<% unless @object.cover_image.blank? %>
 			<div class="dri_cover_image_img">
 				<%= image_tag cover_image_path(@object), width:"228" unless @object.cover_image.blank? %>
-				<p>Current Image</p>
+				<p><%= t('dri.views.catalog.forms.qdc_cur_image')%></p>
 			</div>
 		<% end %>
 		<a class='btn btn-default collection_form' href='javascript:;'>
@@ -21,13 +21,13 @@
 				<%= "#{t('dri.views.fields.cover_image')}"%>
 			</p>
 			<p>
-				(228 x 128px)
+				<%= t('dri.views.catalog.forms.qdc_cover_image_size')%>
 			</p>
-			<label for="digital_object_cover_image" class="visually-hidden">Upload image for collection cover</label>
+			<label for="digital_object_cover_image" class="visually-hidden"><%= t('dri.views.catalog.forms.qdc_cover_image')%></label>
 			<%= f.file_field :cover_image, class: "edit span6",
 			onchange:'coverImageFileUploadHelper($(this));', accept: 'image/*' %>
 			<p class='dri_cover_image_file' id="cover_image">
-				No File
+				<%= t('dri.views.catalog.forms.qdc_no_image')%>
 			</p>
 		</a>
 	</div>

--- a/app/views/shared/_form_object_type.html.erb
+++ b/app/views/shared/_form_object_type.html.erb
@@ -2,14 +2,14 @@
 <label for="<%= "digital_object_type_#{index+1}" %>" class="visually-hidden"><%= t("dri.views.fields.type") %></label>
 <%= select_tag "digital_object[type][]", 
   options_for_select([
-    ["Select Primary Type", ""], 
-    ["text", "text"], 
-    ["image", "image"], 
-    ["movingImage", "movingImage"], 
-    ["interactiveResource", "interactiveResource"],
-    ["3D" , "3D"],
-    ["sound", "sound"], 
-    ["software", "software"],
-    ["dataset", "dataset"]
+    [t('dri.data.types.selectType'), ""], 
+    [t('dri.data.types.Text').downcase, "text"], 
+    [t('dri.data.types.Image').downcase , "image"], 
+    [t('dri.data.types.movingImage') , "movingImage"],
+    [t('dri.data.types.interactiveResource'), "interactiveResource"],
+    [t('dri.data.types.3D'), "3D"],
+    [t('dri.data.types.sound'), "sound"],
+    [t('dri.data.types.Software').downcase , "software"], 
+    [t('dri.data.types.Dataset').downcase , "dataset"], 
   ], selected: type), 
   class: "edit span6 dri-type-dropdown-type", required: true, id: "digital_object_type_#{index+1}" %>

--- a/app/views/shared/_header_browse_change_view.html.erb
+++ b/app/views/shared/_header_browse_change_view.html.erb
@@ -9,7 +9,7 @@
 		  <% changeViewParams[:view] = "list" %>
 		  <%= link_to changeViewParams, id: 'table_view' do %>
 		    <i class="fa fa-list dri_icon_border"></i>
-		    <span class="visually-hidden">View results as list</span>
+		    <span class="visually-hidden"><%= t('dri.help.dri_change_sort_view_list') %></span>
 		  <% end %>
 		  <% if ['catalog','my_collections'].include?(params[:controller]) %>
 		    <% changeViewParams[:view] = "timeline" %>
@@ -17,12 +17,12 @@
 		    <% timelineParams[:tl_field] = @available_timelines.first if @available_timelines %>
 		    <%= link_to timelineParams, id: 'timeline_view' do %>
 		      <i class="fa fa-regular fa-clock dri_icon_border"></i>
-              <span class="visually-hidden">View results on time line</span>
+              <span class="visually-hidden"><%= t('dri.help.dri_change_sort_view_timeline') %></span>
 		    <% end %>
 		    <% changeViewParams[:view] = "maps" %>
 		    <%= link_to changeViewParams, id: 'maps_view' do %>
 		      <i class="fa fa-solid fa-location-dot dri_icon_border"></i>
-              <span class="visually-hidden">View results on map</span>
+              <span class="visually-hidden"><%= t('dri.help.dri_change_sort_view_map') %></span>
 		    <% end %>
 		  <% end %>
 
@@ -30,7 +30,7 @@
 		  <% changeViewParams[:view] = "grid" %>
 		  <%= link_to changeViewParams, id: 'grid_view' do %>
 		    <i class="fa fa-th dri_icon_border"></i>
-		    <span class="visually-hidden">View results as grid</span>
+		    <span class="visually-hidden"><%= t('dri.help.dri_change_sort_view_grid') %></span>
 		  <% end %>
 		  <% changeViewParams[:view] = "list" %>
 		  <i class="fa fa-list dri_icon_border"></i>
@@ -40,12 +40,12 @@
 		    <% timelineParams[:tl_field] = @available_timelines.first if @available_timelines %>
 		    <%= link_to timelineParams, id: 'timeline_view' do %>
 		      <i class="fa fa-regular fa-clock dri_icon_border"></i>
-              <span class="visually-hidden">View results on time line</span>
+              <span class="visually-hidden"><%= t('dri.help.dri_change_sort_view_timeline') %></span>
 		    <% end %>
 		    <% changeViewParams[:view] = "maps" %>
 		    <%= link_to changeViewParams, id: 'maps_view' do %>
 		      <i class="fa fa-solid fa-location-dot dri_icon_border"></i>
-		      <span class="visually-hidden">View results on map</span>
+		      <span class="visually-hidden"><%= t('dri.help.dri_change_sort_view_map') %></span>
 		    <% end %>
 		  <% end %>
 
@@ -57,20 +57,20 @@
 		  <% changeViewParams[:view] = "grid" %>
 		  <%= link_to changeViewParams, id: 'grid_view' do %>
 		    <i class="fa fa-th dri_icon_border"></i>
-            <span class="visually-hidden">View results as grid</span>
+            <span class="visually-hidden"><%= t('dri.help.dri_change_sort_view_grid') %></span>
 		  <% end %>
 		  <% changeViewParams[:view] = "list" %>
-		  <label for="table_view" class="visually-hidden">View results as list</label>
+		  <label for="table_view" class="visually-hidden"><%= t('dri.help.dri_change_sort_view_list') %></label>
 		  <%= link_to changeViewParams, id: 'table_view' do %>
 		    <i class="fa fa-list dri_icon_border"></i>
-		    <span class="visually-hidden">View results as list</span>
+		    <span class="visually-hidden"><%= t('dri.help.dri_change_sort_view_list') %></span>
 		  <% end %>
 		  <% if ['catalog','my_collections'].include?(params[:controller]) %>
 		    <i class="fa fa-regular fa-clock dri_icon_border"></i>
 		    <% changeViewParams[:view] = "maps" %>
 		    <%= link_to changeViewParams, id: 'maps_view' do %>
 		      <i class="fa fa-solid fa-location-dot dri_icon_border"></i>
-		      <span class="visually-hidden">View results on map</span>
+		      <span class="visually-hidden"><%= t('dri.help.dri_change_sort_view_map') %></span>
 		    <% end %>
 		  <% end %>
 
@@ -78,12 +78,12 @@
 		  <% changeViewParams[:view] = "grid" %>
 		  <%= link_to changeViewParams , id: 'grid_view' do %>
 		    <i class="fa fa-th dri_icon_border"></i>
-            <span class="visually-hidden">View results as grid</span>
+            <span class="visually-hidden"><%= t('dri.help.dri_change_sort_view_grid') %></span>
 		  <% end %>
 		  <% changeViewParams[:view] = "list" %>
 		  <%= link_to changeViewParams, id: 'table_view' do %>
 		    <i class="fa fa-list dri_icon_border"></i>
-		    <span class="visually-hidden">View results as list</span>
+		    <span class="visually-hidden"><%= t('dri.help.dri_change_sort_view_list') %></span>
 		  <% end %>
 		  <% if ['catalog','my_collections'].include?(params[:controller]) %>
 		    <% changeViewParams[:view] = "timeline" %>
@@ -91,7 +91,7 @@
 		    <% timelineParams[:tl_field] = @available_timelines.first if @available_timelines %>
 		    <%= link_to timelineParams, id: 'timeline_view' do %>
 		      <i class="fa fa-regular fa-clock dri_icon_border"></i>
-		      <span class="visually-hidden">View results on time line</span>
+		      <span class="visually-hidden"><%= t('dri.help.dri_change_sort_view_timeline') %></span>
 		    <% end %>
 		    <i class="fa fa-solid fa-location-dot dri_icon_border"></i>
 		  <% end %>

--- a/app/views/shared/_header_lang.html.erb
+++ b/app/views/shared/_header_lang.html.erb
@@ -2,14 +2,14 @@
 
 <% if I18n.locale == :en %>
 	<% lang_params[:id] = 'ga' %>
-	<ul class="dropdown">
-		<li>
-			<%= link_to 'English', '#', :"data-toggle" => "dropdown", id: :en %>
+	<ul class="dropdown" role="menu">
+		<li role="presentation">
+			<%= link_to t('dri.application.lang.ga'), '#', :"data-toggle" => "dropdown", id: :en %>
 			<i class="icon-caret-down"></i>
-			<ul class="dropdown-menu">
+			<ul class="dropdown-menu" role="menu">
 				<%= link_to lang_path(lang_params), id: :ga do %>
-				<li>
-					Gaeilge
+				<li role="presentation">
+					<%= t('dri.application.lang.ga') %>
 				</li>
 				<% end %>
 			</ul>
@@ -17,13 +17,13 @@
 	</ul>
 <% else %>
 	<% lang_params[:id] = 'en' %>
-	<ul class="dropdown">
-		<%= link_to 'Gaeilge', '#', :"data-toggle" => "dropdown", id: :ga %>
+	<ul class="dropdown" role="menu">
+		<%= link_to t('dri.application.lang.ga'), '#', :"data-toggle" => "dropdown", id: :ga %>
 		<i class="icon-caret-down"></i>
-		<ul class="dropdown-menu">
+		<ul class="dropdown-menu" role="menu">
 			<%= link_to lang_path(lang_params), id: :en  do %>
-			<li>
-				English
+			<li role="presentation">
+				<%= t('dri.application.lang.en') %>
 			</li>
 			<% end %>
 		</ul>

--- a/app/views/shared/_header_main_nav_lang.html.erb
+++ b/app/views/shared/_header_main_nav_lang.html.erb
@@ -2,24 +2,24 @@
 
 <li class="dropdown dri_dropdown d-sm-none">
 
-	<a href="#" id="dri_manage_id" data-bs-toggle="dropdown" role="button" aria-expanded="false" class="dropdown-toggle"><%= t('dri.headerlinks.language') %> <span class="caret"></span></a>
-
-	<ul class="dropdown-menu">
+	<a href="#" id="dri_manage_id" data-bs-toggle="dropdown" role="button" aria-expanded="false" aria-controls="language-dropdown" class="dropdown-toggle"><%= t('dri.headerlinks.language') %> <span class="caret"></span></a>
+	
+	<ul class="dropdown-menu" role="menu">
 		<% if I18n.locale == :en %>
 		<% lang_params[:id] = 'ga' %>
-		<li class="active">
-			<a>English</a>
+		<li class="active" role="presentation">
+			<a aria-current="page <%= t('dri.application.lang.en') %>" role="menuitem"><%= t('dri.application.lang.en') %></a>
 		</li>
-		<li>
-			<%= link_to 'Gaeilge', main_app.lang_path(lang_params), id: :ga %>
+		<li role="presentation">
+			<%= link_to t('dri.application.lang.ga'), main_app.lang_path(lang_params), id: :ga %>
 		</li>
 		<% else %>
 		<% lang_params[:id] = 'en' %>
-		<li class="active">
-			<a>Gaeilge</a>
+		<li class="active" role="presentation">
+			<a aria-current="page" role="menuitem"><%= t('dri.application.lang.ga') %></a>
 		</li>
-		<li>
-			<%= link_to 'English', main_app.lang_path(lang_params), id: :en %>
+		<li role="presentation">
+			<%= link_to t('dri.application.lang.en'), main_app.lang_path(lang_params), id: :en, role: 'menuitem'%>
 		</li>
 		<% end %>
 	</ul>

--- a/app/views/shared/_header_mobile_lang.html.erb
+++ b/app/views/shared/_header_mobile_lang.html.erb
@@ -6,7 +6,7 @@
     <li>
 
       <%= link_to '#',:"data-bs-toggle" => "dropdown" do %>
-        English <i class="fa fa-sml fa-caret-down"></i> 
+        <%= t('dri.application.lang.en') %> <i class="fa fa-sml fa-caret-down"></i> 
       <% end %>
 
       <ul class="dropdown-menu">
@@ -21,7 +21,7 @@
     <li>
 
       <%= link_to '#', :"data-bs-toggle" => "dropdown" do %>
-        Gaeilge <i class="fa fa-sml fa-caret-down"></i> 
+        <%= t('dri.application.lang.ga') %> <i class="fa fa-sml fa-caret-down"></i> 
       <% end %>
 
       <ul class="dropdown-menu">

--- a/app/views/shared/_header_navbar_user.html.erb
+++ b/app/views/shared/_header_navbar_user.html.erb
@@ -5,7 +5,7 @@
 
       <%= link_to user_group.profile_path, :id => 'view_account' do %>
           <i class="fa fa-user"></i>
-          <span class="visually-hidden">Repository User Profile</span>
+          <span class="visually-hidden"> <%= t('dri.headerlinks.user_profile') %></span>
       <% end %>
     </div>
   </nav>

--- a/app/views/tp_data/edit.html.erb
+++ b/app/views/tp_data/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="dri_main_content_container">
-		 <h3>Review Transcribathon Enrichments</h3>
+		 <h3><%= t('dri.views.catalog.forms.tp_review')%></h3>
 
 
 
@@ -11,22 +11,22 @@
 
     <%= render partial: 'shared/surrogate' %>
 
-    <h4>Original object metadata</h4>
+    <h4><%= t('dri.views.catalog.forms.tp_original_metadata')%></h4>
     <dl class="dri_object_metadata_readview">
-      <dt>Type</dt>
+      <dt><%= t('dri.views.catalog.forms.tp_type')%></dt>
       <dd>
         <% @document.type.each do |field| %>
           <%= field %><br/>
         <% end %>
       </dd>
-      <dt>Creators and Contributors</dt>
+      <dt><%= t('dri.views.fields.creators')%> and <%= t('dri.views.fields.contributors')%></dt>
       <dd>
         <% @document['person_tesim'].each do |field| %>
           <%= field %><br/>
         <% end %>
       </dd>
       <% if @document['subject_tesim'].present? %>
-        <dt>Subjects</dt>
+        <dt><%= t('dri.views.fields.subjects')%></dt>
         <dd>
           <% @document['subject_tesim'].each do |field| %>
             <%= field %><br/>
@@ -34,7 +34,7 @@
         </dd>
       <% end %>
       <% if @document.date.present? %>
-        <dt>Dates</dt>
+        <dt><%= t('dri.views.fields.dates')%></dt>
         <dd>
           <% @document.date.each do |field| %> 
             <%= field %><br/>
@@ -42,7 +42,7 @@
         </dd>
       <% end %>
       <% if @document.creation_date.present? %>
-        <dt>Creation Dates</dt>
+        <dt><%= t('dri.views.fields.creation_dates')%></dt>
         <dd>
           <% @document.creation_date.each do |field| %>
             <%= field %><br/>
@@ -50,7 +50,7 @@
         </dd>
       <% end %>
       <% if @document.published_date.present? %>
-        <dt>Published Dates</dt>
+        <dt><%= t('dri.views.fields.published_dates')%></dt>
         <dd>
           <% @document.published_date.each do |field| %> 
             <%= field %><br/>
@@ -58,7 +58,7 @@
         </dd>
       <% end %>
       <% if @document['temporal_coverage_tesim'].present? %>
-        <dt>Temporal Coverage</dt>
+        <dt><%= t('dri.views.fields.temporal_coverage')%></dt>
         <dd>
           <% @document['temporal_coverage_tesim'].each do |field| %> 
             <%= field %><br/>
@@ -66,7 +66,7 @@
         </dd>
       <% end %>
       <% if @document['geographical_coverage_tesim'].present? %>
-        <dt>Geographical Coverage</dt>
+        <dt><%= t('dri.views.fields.geographical_coverages')%></dt>
         <dd>
           <% @document['geographical_coverage_tesim'].each do |field| %>
             <%= field %><br/>
@@ -79,30 +79,30 @@
 
 
 <div class="dri_section_block">
-  <h4>Metadata Enrichments</h4>
+  <h4><%= t('dri.views.catalog.forms.tp_enrichments')%></h4>
 
-  <h5>Overall Start and End dates</h5>
+  <h5><%= t('dri.views.catalog.forms.tp_overall_dates')%></h5>
   <dl>
-    <dt>Start Date</dt>
+    <dt><%= t('dri.views.catalog.forms.tp_start_date')%></dt>
     <% if not @earliest_item.present? %>
-      <dd>No start dates entered</dd>
+      <dd><%= t('dri.views.catalog.forms.tp_no_start_date')%></dd>
       <dt></td>
     <% else %>
       <dd> <%= @earliest_item.start_date %> </dd>
-      <dt>Appears on the following page(s)</dt>
+      <dt><%= t('dri.views.catalog.forms.tp_following_pages')%></dt>
       <dd> <% @early_items.each do |item| %>
            <%= link_to "#{item.item_id}", item.item_link, :target => "_blank" %><br/>
           <% end %>
       </dd>
     <% end %>
 
-    <dt>End Date</dt>
+    <dt><%= t('dri.views.catalog.forms.tp_end_date')%></dt>
     <% if not @latest_item.present? %>
-      <dd>No end date entered</dd>
+      <dd><%= t('dri.views.catalog.forms.tp_no_end_date')%></dd>
       <dt></dt>
     <% else %>
       <dd> <%= @latest_item.end_date %> </dd>
-      <dt>Appears on the following page(s)</dt>
+      <dt><%= t('dri.views.catalog.forms.tp_following_pages')%></dt>
       <dd> <% @late_items.each do |item| %>
             <%= link_to "#{item.item_id}", item.item_link, :target => "_blank" %><br/>
            <% end %>
@@ -112,11 +112,11 @@
 
   <p>
     <%= check_box_tag(:accept_start_end_dates) %>
-    <%= label_tag(:pet_cat, "Accept these dates and add to authoritative metadata?") %>
+    <%= label_tag(:pet_cat, t('dri.views.catalog.forms.tp_accept_dates')) %>
   </p>
 
 
-  <p>See more?</p>
+  <p><%= t('dri.views.catalog.forms.qdc_see_more')%></p>
 
   <% page = 1 %>
   <span><% @items.each do |item| %>
@@ -126,7 +126,7 @@
                 <%= "#{item.start_date} - #{item.end_date}:" %>
                 <%= link_to "Page #{page}: #{item.item_id}", item.item_link, :target => "_blank" %>
                 <%= check_box_tag(:accept_start_end_dates) %>
-                <%= label_tag(:accept_start_end_dates, "Accept these dates and add to authoritative metadata?") %>
+                <%= label_tag(:accept_start_end_dates, t('dri.views.catalog.forms.tp_accept_dates')) %>
               </li>
             </ul>
           <% end %>

--- a/config/locales/dri/en.yml
+++ b/config/locales/dri/en.yml
@@ -21,7 +21,7 @@ en:
         delete_help: Note that you cannot delete your account if you currently have read, edit or manager permissions on any collection. Please modify your permissions first.
       lang:
         en: English
-        ga: Irish
+        ga: Gaeilge
       terms:
         accept: I agree
         deposit_agreement: I agree to the terms of Deposit Agreement
@@ -66,16 +66,22 @@ en:
         not_saved: Unable to save collection options
     data:
       types:
+        selectType: Select Primary Type
         Image: Image
         MixedType: Mixed Types
         MovingImage: Video
+        movingImage: movingImage
         Sound: Audio
+        sound: sound
+        Software: Software
+        Dataset: Dataset
         Text: Text
         3D: 3D
         Title: Media Types
         Unknown: Unknown
         all: All
         InteractiveResource: Interactive Resource
+        interactiveResource: interactiveResource
     datatables:
       activity:
         committer: Committer
@@ -241,6 +247,7 @@ en:
         street: 19 Dawson Street
         zip: Dublin 2
     headerlinks:
+      user_profile:  Repository User Profile
       newsletter: Newsletter
       news_events: "News & Events"
       about: About
@@ -272,6 +279,7 @@ en:
       manage_om_users: Assign Manager
       deposit: Deposit
       membership: DRI Membership
+      membership_link: 'https://www.dri.ie/membership'
       community_archive: Community Archive Scheme
       heritage_week_2020: HeritageWeek2020
       my_collections: My Collections
@@ -341,6 +349,10 @@ en:
       dri_browse_sort_tabs_sub_collection_title: Sub-Collections Search
       dri_change_sort_view: 'Use these buttons to select between a Grid, Tabular, Timeline or Map layout for your search result'
       dri_change_sort_view_title: Search Result Layout
+      dri_change_sort_view_list: View results as list
+      dri_change_sort_view_timeline: View results on time line
+      dri_change_sort_view_map: View results on map
+      dri_change_sort_view_grid: View results as grid
       dri_facet_restrictions_links: "These are the Facets which are narrowing your search. You can disable them individually or 'Clear All'"
       dri_facet_restrictions_links_title: Selected Facets
       dri_page_options: Select from this list to choose the number of items shown on each page
@@ -481,6 +493,22 @@ en:
           copy_to_clipboard: Copy to Clipboard 
           copy_success: Copied to Clipboard
           copy_failure: Not copied
+          tp_original_metadata: Original object metadata
+          tp_type: Type
+          tp_review: Review Transcribathon Enrichments
+          tp_enrichments: Metadata Enrichments
+          tp_overall_dates: Overall Start and End dates
+          tp_start_date: Start Date
+          tp_no_start_date: No start dates entered
+          tp_following_pages: Appears on the following page(s)
+          tp_end_date: End Date
+          tp_no_end_date: No end date entered
+          tp_accept_dates: Accept these dates and add to authoritative metadata?
+          qdc_cur_image: Current Image
+          qdc_no_image: No File
+          qdc_cover_image: Upload image for collection cover
+          qdc_cover_image_size: (228 x 128px)
+          qdc_see_more: See more?
         headers:
           files: Asset Tools
           related_materials: Related Materials
@@ -727,6 +755,7 @@ en:
           upload: Upload Metadata file
       institutes:
         orgs_legend: "Organisations listed on this page are associated in various ways with deposited collections. They include depositing organisations, contributing partners, collaborating institutions, and funding agencies. For a list of DRI Members, see the <a href='%{url}'>Membership page</a>."
+        org_aria_label: 'Explore Collections of '
       licences:
         collection: Please see individual objects for licensing information
         collection_mgr: "%{licence} - this licence will be set on objects in this collection unless overridden"
@@ -910,3 +939,13 @@ en:
          user_activity_report: User Activity
       object:
          metadata_md5: Metadata Checksum
+    server_error:
+      404_error: Error 404 - Page not found
+      404_message: The page you were looking for doesn't exist.
+      404_explanation: You may have mistyped the address or the page may have moved.
+      422_error: Error 422 - Request rejected
+      422_message: The change you wanted was rejected.
+      422_explanation: Maybe you tried to change something you didn't have access to.
+      500_error: Error 500 - Internal Server Error
+      500_message: The server encountered an error and could not complete your request.
+      500_explanation: The server encountered an unexpected condition that prevented it from fulfilling the request.

--- a/public/404.html
+++ b/public/404.html
@@ -1,26 +1,48 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-  <title>The page you were looking for doesn't exist (404)</title>
-  <style type="text/css">
-    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
-    div.dialog {
-      width: 25em;
-      padding: 0 4em;
-      margin: 4em auto 0 auto;
-      border: 1px solid #ccc;
-      border-right-color: #999;
-      border-bottom-color: #999;
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page not found · DRI</title>
+
+  <style>
+    body.error_page {
+      background-color: white;
+      color: #2f2f2f;
+      text-align: center;
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
     }
-    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+
+    main {
+      width: 90%;
+      padding: 2em;
+      margin: 4em auto;
+      border: 1px solid #cccccc;
+      border-right-color: #9e9e9e;
+      border-bottom-color: #9e9e9e;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    }
+
+    h1 {
+      font-size: 24px;
+      color: red;
+      margin-bottom: 1em;
+    }
+
+    p {
+      font-size: 18px;
+      color: black;
+    }
   </style>
 </head>
 
-<body>
-  <!-- This file lives in public/404.html -->
-  <div class="dialog">
-    <h1>The page you were looking for doesn't exist.</h1>
+<body class="error_page">
+  <main class="dialog" role="main">
+    <h1 aria-live="assertive">Error 404 - Page not found</h1>
+    <h1 aria-live="assertive">The page you were looking for doesn't exist.</h1>
     <p>You may have mistyped the address or the page may have moved.</p>
-  </div>
+  </main>
 </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -1,26 +1,48 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-  <title>The change you wanted was rejected (422)</title>
-  <style type="text/css">
-    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
-    div.dialog {
-      width: 25em;
-      padding: 0 4em;
-      margin: 4em auto 0 auto;
-      border: 1px solid #ccc;
-      border-right-color: #999;
-      border-bottom-color: #999;
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Request rejected · DRI</title>
+
+  <style>
+    body.error_page {
+      background-color: white;
+      color: #2f2f2f;
+      text-align: center;
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
     }
-    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+
+    main {
+      width: 90%;
+      padding: 2em;
+      margin: 4em auto;
+      border: 1px solid #cccccc;
+      border-right-color: #9e9e9e;
+      border-bottom-color: #9e9e9e;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    }
+
+    h1 {
+      font-size: 24px;
+      color: red;
+      margin-bottom: 1em;
+    }
+
+    p {
+      font-size: 18px;
+      color: black;
+    }
   </style>
 </head>
 
-<body>
-  <!-- This file lives in public/422.html -->
-  <div class="dialog">
-    <h1>The change you wanted was rejected.</h1>
+<body class="error_page">
+  <main class="dialog" role="main">
+    <h1 aria-live="assertive">Error 422 - Request rejected</h1>
+    <h1 aria-live="assertive">The change you wanted was rejected.</h1>
     <p>Maybe you tried to change something you didn't have access to.</p>
-  </div>
+  </main>
 </body>
 </html>

--- a/public/500.html
+++ b/public/500.html
@@ -1,25 +1,48 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
-  <title>We're sorry, but something went wrong (500)</title>
-  <style type="text/css">
-    body { background-color: #fff; color: #666; text-align: center; font-family: arial, sans-serif; }
-    div.dialog {
-      width: 25em;
-      padding: 0 4em;
-      margin: 4em auto 0 auto;
-      border: 1px solid #ccc;
-      border-right-color: #999;
-      border-bottom-color: #999;
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Internal Server Error · DRI</title>
+
+  <style>
+    body.error_page {
+      background-color: white;
+      color: #2f2f2f;
+      text-align: center;
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
     }
-    h1 { font-size: 100%; color: #f00; line-height: 1.5em; }
+
+    main {
+      width: 90%;
+      padding: 2em;
+      margin: 4em auto;
+      border: 1px solid #cccccc;
+      border-right-color: #9e9e9e;
+      border-bottom-color: #9e9e9e;
+      box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+    }
+
+    h1 {
+      font-size: 24px;
+      color: red;
+      margin-bottom: 1em;
+    }
+
+    p {
+      font-size: 18px;
+      color: black;
+    }
   </style>
 </head>
 
-<body>
-  <!-- This file lives in public/500.html -->
-  <div class="dialog">
-    <h1>We're sorry, but something went wrong.</h1>
-  </div>
+<body class="error_page">
+  <main class="dialog" role="main">
+    <h1 aria-live="assertive">Error 500 - Internal Server Error</h1>
+    <h1 aria-live="assertive">The server encountered an error and could not complete your request.</h1>
+    <p>The server encountered an unexpected condition that prevented it from fulfilling the request.</p>
+  </main>
 </body>
 </html>


### PR DESCRIPTION
Removed as much strings as possible from multiple files and added to en.yml
Minor change in style of server error pages:
Image 1: New Style.
![image](https://github.com/user-attachments/assets/9260af76-0488-4a02-be63-f9a28006371f)


Image 2: Old Style.
![image](https://github.com/user-attachments/assets/fda26620-fa47-4cd5-a080-d6ffac34a052)


**IMPORTANT:**
Created a translation list for review [HERE.](https://docs.google.com/spreadsheets/d/1EIANiX0P_0GL08h6yD5UAV4bkxp6gwiQ/edit?usp=sharing&ouid=102908790964401475941&rtpof=true&sd=true) for future implementation of ga.yml